### PR TITLE
Alternate move functionality added(Turn Fixed)

### DIFF
--- a/public/javascript/chess/board.js
+++ b/public/javascript/chess/board.js
@@ -1,6 +1,7 @@
 var Board = function(config){
     this.root_id = config.root_id;
     this.$el = document.getElementById(this.root_id);
+    this.currentPlayer = 'white';
     this.generateBoardDom();
     this.addListeners();
 }
@@ -199,3 +200,9 @@ Board.prototype.renderAllPieces = function() {
         }
     });
 };
+
+Board.prototype.switchPlayer = function(){
+    // Toggling the color each time to change currentPlayer
+    this.currentPlayer = this.currentPlayer === 'white' ? 'black' : 'white';
+    this.selectedPiece = false;
+}

--- a/public/javascript/chess/pieces/bishop.js
+++ b/public/javascript/chess/pieces/bishop.js
@@ -6,9 +6,10 @@ var Bishop = function(config){
 Bishop.prototype = new Piece({});
 
 Bishop.prototype.moveTo = function(newPosition){
-    if(this.isValidPosition(newPosition)){
+    if(this.isValidPosition(newPosition) && this.color === this.board.currentPlayer){
         this.position = newPosition.col + newPosition.row;
         this.render();
+        this.board.switchPlayer();
     }else{
         throw new Error("Invalid Bishop move");
     }

--- a/public/javascript/chess/pieces/king.js
+++ b/public/javascript/chess/pieces/king.js
@@ -24,9 +24,10 @@ King.prototype.isValidPosition = function(targetPosition) {
 };
 
 King.prototype.moveTo = function(targetPosition) {
-    if (this.isValidPosition(targetPosition)) {
+    if (this.isValidPosition(targetPosition) && this.color === this.board.currentPlayer) {
         this.position = targetPosition.col + targetPosition.row;
         this.render();
+        this.board.switchPlayer();
     } else {
         console.warn("Move not allowed");
     }

--- a/public/javascript/chess/pieces/knight.js
+++ b/public/javascript/chess/pieces/knight.js
@@ -6,9 +6,10 @@ var Knight = function(config) {
 Knight.prototype = new Piece({});
 
 Knight.prototype.moveTo = function(newPosition) {
-    if (this.isValidPosition(newPosition)) {
+    if (this.isValidPosition(newPosition) && this.color === this.board.currentPlayer) {
         this.position = newPosition.col + newPosition.row;
         this.render();
+        this.board.switchPlayer();
     } else {
         throw new Error("Invalid Knight move");
     }

--- a/public/javascript/chess/pieces/pawn.js
+++ b/public/javascript/chess/pieces/pawn.js
@@ -38,9 +38,10 @@ Pawn.prototype.isValidPosition = function(targetPosition){
 }
 
 Pawn.prototype.moveTo = function(targetPosition){    
-    if(this.isValidPosition(targetPosition)){
+    if(this.isValidPosition(targetPosition) && this.color === this.board.currentPlayer){
         this.position = targetPosition.col + targetPosition.row;
         this.render();
+        this.board.switchPlayer();
     }else{
         //NOOP
     }

--- a/public/javascript/chess/pieces/queen.js
+++ b/public/javascript/chess/pieces/queen.js
@@ -5,9 +5,10 @@ var Queen = function(config){
 
 Queen.prototype = new Piece({});
 Queen.prototype.moveTo = function(newPosition){
-    if(this.isValidPosition(newPosition)){
+    if(this.isValidPosition(newPosition) && this.color === this.board.currentPlayer){
         this.position = newPosition.col + newPosition.row;
         this.render();
+        this.board.switchPlayer();
     }else{
         throw new Error("Invalid Queen move");
     }

--- a/public/javascript/chess/pieces/rook.js
+++ b/public/javascript/chess/pieces/rook.js
@@ -7,9 +7,10 @@ var Rook = function(config){
 
 Rook.prototype = new Piece({});
 Rook.prototype.moveTo = function(newPosition){
-    if(this.isValid(newPosition)){
+    if(this.isValid(newPosition) && this.color === this.board.currentPlayer){
         this.position = newPosition.col + newPosition.row;
         this.render();
+        this.board.switchPlayer();
     }else{
         throw new Error("The path is invalid");
     }


### PR DESCRIPTION
---
# PR Description: Enforce Turn-Based Movement for Chess Pieces

## Summary:
This PR introduces functionality that ensures pieces can only be moved by the current player, based on their assigned color (white or black). The following updates were made:

1. **Added Turn-Based Logic:**
   - Implemented a `switchPlayer` method in the `Board` class that toggles between the current player (`white` or `black`) after a valid move.
   - Updated all piece classes (`King`, `Queen`, `Bishop`, `Knight`, `Rook`, `Pawn`) to verify that the moving piece belongs to the current player before allowing movement.

2. **Error Handling:**
   - If a player tries to move a piece that doesn't belong to them, an error or warning is raised (`"Move not allowed"` for King, `"Invalid move"` for others).

3. **Consistency:**
   - Updated all piece classes to call `this.board.switchPlayer()` after a valid move to ensure proper alternation between players.

## Changes:
- `board.js`: Added the `switchPlayer` method to toggle between players after each move.
- Piece classes (`king.js`, `queen.js`, `bishop.js`, `knight.js`, `rook.js`, `pawn.js`): Ensured that only the current player's piece can be moved, and added the `switchPlayer` call after successful moves.

# Demo - 

https://github.com/user-attachments/assets/8aa677f8-4248-457e-b8a3-f75d69f99635


---
