### PR TITLE
Dynamic toggle functionality anyone can start the game

### DIFF
--- a/public/javascript/chess/board.js
+++ b/public/javascript/chess/board.js
@@ -1,7 +1,7 @@
 var Board = function(config){
     this.root_id = config.root_id;
     this.$el = document.getElementById(this.root_id);
-    this.currentPlayer = 'white';
+    this.currentPlayer = '';
     this.generateBoardDom();
     this.addListeners();
 }

--- a/public/javascript/chess/piece.js
+++ b/public/javascript/chess/piece.js
@@ -44,5 +44,5 @@ Piece.prototype.render = function(){
 }
 
 Piece.prototype.kill = function(targetPiece){
-    console.log("Method not implemeted by: " + typeof(this));
+    // console.log("Method not implemeted by: " + typeof(this));
 }

--- a/public/javascript/chess/pieces/knight.js
+++ b/public/javascript/chess/pieces/knight.js
@@ -6,9 +6,12 @@ var Knight = function(config) {
 Knight.prototype = new Piece({});
 
 Knight.prototype.moveTo = function(newPosition) {
-    if (this.isValidPosition(newPosition) && this.color === this.board.currentPlayer) {
+    if (this.isValidPosition(newPosition) && (this.color === this.board.currentPlayer || this.board.currentPlayer=='')) {
         this.position = newPosition.col + newPosition.row;
         this.render();
+        if(this.board.currentPlayer==''){
+            this.board.currentPlayer = this.color;
+        }
         this.board.switchPlayer();
     } else {
         throw new Error("Invalid Knight move");

--- a/public/javascript/chess/pieces/pawn.js
+++ b/public/javascript/chess/pieces/pawn.js
@@ -38,9 +38,12 @@ Pawn.prototype.isValidPosition = function(targetPosition){
 }
 
 Pawn.prototype.moveTo = function(targetPosition){    
-    if(this.isValidPosition(targetPosition) && this.color === this.board.currentPlayer){
+    if(this.isValidPosition(targetPosition) && (this.color === this.board.currentPlayer || this.board.currentPlayer=='')){
         this.position = targetPosition.col + targetPosition.row;
         this.render();
+        if(this.board.currentPlayer==''){
+            this.board.currentPlayer = this.color;
+        }
         this.board.switchPlayer();
     }else{
         //NOOP


### PR DESCRIPTION
# Title:
Add Dynamic Toggle for Player Initialization in Chess Game

## Description:
This update introduces a dynamic toggle feature allowing any player (either black or white) to start the game, depending on who makes the first move. It enhances the gameplay flexibility and resolves the issue where the game required a fixed player to always start as white.

## Key Changes:
1. **board.js**: 
   - Updated the `currentPlayer` to initialize as an empty string, indicating that either player can start.

2. **knight.js** and **pawn.js**: 
   - Modified the `moveTo` method to allow a move even when `currentPlayer` is not set, assigning the current player based on who makes the first move.
   - After the first move, the game alternates between players as usual.

---